### PR TITLE
Support version pinning in deb and yum repos

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,9 @@ platforms:
   - name: centos-6.5
     run_list:
     - recipe[yum]
+  - name: centos-7.1
+    run_list:
+    - recipe[yum]
   - name: windows-2012R2
     driver:
       box: mwrock/Windows2012R2

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'vir.khatri@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Elastic Topbeat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.3'
+version '0.1.4'
 
 source_url 'https://github.com/vkhatri/chef-topbeat' if respond_to?(:source_url)
 issues_url 'https://github.com/vkhatri/chef-topbeat/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Hi - Thanks for taking the time to create such a useful cookbook. I am submitting a pull request which addresses some of the challenges that we have had using this cookbook in a production environment. This cookbook is of the option that you should only install a version of the topbeat package as specific in the metadata. This is generally good practice for repositories like elastic who publish all major versions to the same repository (last night they released 1.3). The problem with installing a specific version is that if your shop uses yum and apt commands to patch the latest vulnerabilities, your system will automatically install the latest version of the package. 

This causes a couple of issues 1) You are no longer running the version that you specified in the recipe 2) You will face errors installing the right version at the next run 3) You will constantly fight the update command. 

To address these issues I have updated the cookbook to pin versions for `apt` repositories and to lock versions with `yum` repositories. The net effect is that yum and apt will no longer try to update topbeat and the version being installed is controlled by this cookbook. 

Let me know what you think.

🍻 
